### PR TITLE
Feature/updates

### DIFF
--- a/PACKAGES.md
+++ b/PACKAGES.md
@@ -54,6 +54,13 @@ alacritty # Alternative terminal emulator
 foot # Another minimal terminal option
 dunst # Alternative notification daemon
 
+## SDDM Theme (Login Screen)
+
+sddm # Simple Desktop Display Manager
+qt5-graphicaleffects # Qt5 graphical effects for SDDM themes
+qt5-quickcontrols2 # Qt5 quick controls for SDDM themes
+qt5-svg # Qt5 SVG support for SDDM themes
+
 ## Development Tools (Optional)
 
 neovim # Modal text editor

--- a/README.md
+++ b/README.md
@@ -154,6 +154,62 @@ If you prefer to install packages yourself:
     - Select **Hyprland** from your display manager (SDDM/GDM).
     - Log in.
 
+### 🎨 SDDM Login Screen Theme (Optional)
+
+To apply the **Catppuccin Mocha** theme to your SDDM login screen:
+
+**Automated Installation:**
+
+```bash
+sudo ./install_sddm_theme.sh
+```
+
+This script will:
+- Install required Qt5 dependencies (`qt5-graphicaleffects`, `qt5-quickcontrols2`, `qt5-svg`)
+- Clone and install the Catppuccin Mocha SDDM theme
+- Configure SDDM to use the theme
+- Sync your desktop wallpaper to the login screen
+- Provide test commands for verification
+
+**Testing the Theme:**
+
+```bash
+# Test mode (may not work on all systems)
+sddm-greeter --test-mode --theme /usr/share/sddm/themes/catppuccin-mocha
+
+# Or simply reboot to see the login screen
+sudo reboot
+```
+
+**Manual Installation:**
+
+If you prefer to install manually:
+
+1.  **Install Dependencies:**
+    ```bash
+    sudo pacman -S --needed qt5-graphicaleffects qt5-quickcontrols2 qt5-svg sddm
+    ```
+
+2.  **Install Theme:**
+    ```bash
+    git clone https://github.com/catppuccin/sddm.git /tmp/catppuccin-sddm
+    sudo cp -r /tmp/catppuccin-sddm/src/catppuccin-mocha /usr/share/sddm/themes/
+    rm -rf /tmp/catppuccin-sddm
+    ```
+
+3.  **Configure SDDM:**
+    ```bash
+    sudo mkdir -p /etc/sddm.conf.d
+    echo -e "[Theme]\nCurrent=catppuccin-mocha" | sudo tee /etc/sddm.conf.d/theme.conf
+    ```
+
+4.  **Sync Wallpaper (Optional):**
+    ```bash
+    sudo mkdir -p /usr/share/sddm/themes/catppuccin-mocha/backgrounds
+    sudo cp ~/.config/hypr/wallpapers/digital_art.jpg /usr/share/sddm/themes/catppuccin-mocha/backgrounds/wall.jpg
+    sudo sed -i 's|^Background=.*|Background=backgrounds/wall.jpg|' /usr/share/sddm/themes/catppuccin-mocha/theme.conf
+    ```
+
 > **Note**: If you are on a laptop, ensure `brightnessctl` is working for backlight keys.
 
 ## 📄 License

--- a/install.sh
+++ b/install.sh
@@ -158,3 +158,17 @@ echo "  SUPER + F            - Fullscreen"
 echo "  SUPER + W            - Cycle Wallpapers"
 echo "  SUPER + [1-9]        - Switch Workspace"
 echo ""
+echo -e "${YELLOW}Optional: Install SDDM Theme (Catppuccin Mocha)?${NC}"
+echo "This will theme your login screen to match the desktop."
+echo "Requires sudo privileges."
+read -p "Install SDDM theme? (y/n) " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    if [ -f "$SCRIPT_DIR/install_sddm_theme.sh" ]; then
+        echo -e "${GREEN}Installing SDDM theme...${NC}"
+        sudo "$SCRIPT_DIR/install_sddm_theme.sh"
+    else
+        echo -e "${RED}Error: install_sddm_theme.sh not found${NC}"
+    fi
+fi
+echo ""

--- a/install_sddm_theme.sh
+++ b/install_sddm_theme.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+# SDDM Theme Installation Script for Zero-Drag Hyprland dotfiles
+# Installs Catppuccin Mocha theme to match the desktop environment
+
+set -e
+
+echo "========================================="
+echo "SDDM Catppuccin Mocha Theme Installer"
+echo "Zero-Drag Login Screen Theme"
+echo "========================================="
+echo ""
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Check if running as root or with sudo
+if [ "$EUID" -ne 0 ]; then 
+    echo -e "${RED}Error: This script must be run as root or with sudo${NC}"
+    echo "Usage: sudo ./install_sddm_theme.sh"
+    exit 1
+fi
+
+# Store the real user's home directory (in case script is run with sudo)
+if [ -n "$SUDO_USER" ]; then
+    REAL_USER="$SUDO_USER"
+    REAL_HOME=$(getent passwd "$SUDO_USER" | cut -d: -f6)
+else
+    REAL_USER="$USER"
+    REAL_HOME="$HOME"
+fi
+
+echo -e "${GREEN}Step 1: Installing Qt5 dependencies for SDDM themes...${NC}"
+echo ""
+
+# Install required Qt5 modules
+DEPENDENCIES=(
+    "qt5-graphicaleffects"
+    "qt5-quickcontrols2"
+    "qt5-svg"
+    "sddm"
+)
+
+echo "Installing: qt5-graphicaleffects qt5-quickcontrols2 qt5-svg sddm"
+pacman -S --needed --noconfirm "${DEPENDENCIES[@]}"
+
+echo ""
+echo -e "${GREEN}Step 2: Installing Catppuccin Mocha theme...${NC}"
+echo ""
+
+# Create temporary directory
+TEMP_DIR=$(mktemp -d)
+echo "Using temporary directory: $TEMP_DIR"
+
+# Clone the Catppuccin SDDM repository
+echo "Cloning Catppuccin SDDM theme repository..."
+if ! git clone https://github.com/catppuccin/sddm.git "$TEMP_DIR/catppuccin-sddm"; then
+    echo -e "${RED}Error: Failed to clone the theme repository${NC}"
+    echo "Please check your internet connection and try again."
+    rm -rf "$TEMP_DIR"
+    exit 1
+fi
+
+# Create themes directory if it doesn't exist
+mkdir -p /usr/share/sddm/themes/
+
+# Copy the Mocha theme
+echo "Installing catppuccin-mocha theme..."
+cp -r "$TEMP_DIR/catppuccin-sddm/src/catppuccin-mocha" /usr/share/sddm/themes/
+
+echo ""
+echo -e "${GREEN}Step 3: Configuring SDDM to use Catppuccin Mocha...${NC}"
+echo ""
+
+# Create SDDM config directory if it doesn't exist
+mkdir -p /etc/sddm.conf.d
+
+# Create theme configuration
+cat > /etc/sddm.conf.d/theme.conf << 'EOF'
+[Theme]
+Current=catppuccin-mocha
+EOF
+
+echo "Created /etc/sddm.conf.d/theme.conf"
+
+echo ""
+echo -e "${GREEN}Step 4: Syncing wallpaper with desktop...${NC}"
+echo ""
+
+# Check if the user's wallpaper exists
+# Note: Using digital_art.jpg as specified in the Zero-Drag configuration
+# Users can manually change this to sync a different wallpaper if needed
+WALLPAPER_SOURCE="$REAL_HOME/.config/hypr/wallpapers/digital_art.jpg"
+WALLPAPER_DEST="/usr/share/sddm/themes/catppuccin-mocha/backgrounds/wall.jpg"
+
+if [ -f "$WALLPAPER_SOURCE" ]; then
+    echo "Found wallpaper: $WALLPAPER_SOURCE"
+    
+    # Create backgrounds directory if it doesn't exist
+    mkdir -p /usr/share/sddm/themes/catppuccin-mocha/backgrounds
+    
+    # Copy wallpaper
+    cp "$WALLPAPER_SOURCE" "$WALLPAPER_DEST"
+    echo "Wallpaper copied to: $WALLPAPER_DEST"
+    
+    # Update theme.conf to use the wallpaper
+    THEME_CONF="/usr/share/sddm/themes/catppuccin-mocha/theme.conf"
+    
+    if [ -f "$THEME_CONF" ]; then
+        # Update the Background parameter to point to wall.jpg
+        sed -i 's|^Background=.*|Background=backgrounds/wall.jpg|' "$THEME_CONF"
+        echo "Updated theme configuration to use synced wallpaper"
+    else
+        echo -e "${YELLOW}Warning: theme.conf not found at $THEME_CONF${NC}"
+    fi
+else
+    echo -e "${YELLOW}Warning: Wallpaper not found at $WALLPAPER_SOURCE${NC}"
+    echo "The default theme wallpaper will be used."
+    echo "You can manually copy your wallpaper later with:"
+    echo "  sudo cp ~/.config/hypr/wallpapers/digital_art.jpg $WALLPAPER_DEST"
+    echo "  sudo sed -i 's|^Background=.*|Background=backgrounds/wall.jpg|' /usr/share/sddm/themes/catppuccin-mocha/theme.conf"
+fi
+
+echo ""
+echo -e "${GREEN}Step 5: Cleaning up temporary files...${NC}"
+echo ""
+
+# Remove temporary directory
+rm -rf "$TEMP_DIR"
+echo "Temporary files cleaned up"
+
+echo ""
+echo -e "${GREEN}=========================================${NC}"
+echo -e "${GREEN}SDDM Theme Installation Complete!${NC}"
+echo -e "${GREEN}=========================================${NC}"
+echo ""
+echo -e "${YELLOW}Next Steps:${NC}"
+echo "1. Test the theme (without rebooting):"
+echo "   ${GREEN}sddm-greeter --test-mode --theme /usr/share/sddm/themes/catppuccin-mocha${NC}"
+echo ""
+echo "2. Reboot to see the new login screen:"
+echo "   ${GREEN}sudo reboot${NC}"
+echo ""
+echo -e "${YELLOW}Note:${NC} The test mode may not work on all systems."
+echo "If test mode fails, just reboot to see the login screen."
+echo ""
+echo -e "${YELLOW}Troubleshooting:${NC}"
+echo "- If the theme doesn't apply, check: cat /etc/sddm.conf.d/theme.conf"
+echo "- Verify theme exists: ls /usr/share/sddm/themes/catppuccin-mocha"
+echo "- Check SDDM logs: journalctl -u sddm -b"
+echo ""


### PR DESCRIPTION
This pull request adds support for theming the SDDM login screen with the Catppuccin Mocha theme, providing both automated and manual installation options. It introduces a new installation script, updates installation instructions, and lists the necessary dependencies for SDDM theming.

**SDDM Theme Support:**

* Added a new script `install_sddm_theme.sh` to automate installing and configuring the Catppuccin Mocha SDDM login screen theme, including syncing the desktop wallpaper and providing troubleshooting/test instructions.
* Updated `install.sh` to prompt the user to optionally install the SDDM theme via the new script during setup.
* Added SDDM and required Qt5 dependencies (`qt5-graphicaleffects`, `qt5-quickcontrols2`, `qt5-svg`) to the package list in `PACKAGES.md`.

**Documentation Updates:**

* Expanded `README.md` with detailed instructions for both automated and manual installation of the Catppuccin Mocha SDDM theme, including dependency installation, theme configuration, wallpaper syncing, and testing the login screen.