### PR TITLE
feat: migrate wiki sync from GitHub Wiki to VitePress-powered GitHub …

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,22 +1,49 @@
-name: Sync docs to Wiki
+name: Deploy to GitHub Pages
 on:
   push:
-    branches:
-      - main
-    paths:
-      - 'docs/wiki/**'
+    branches: [main]
+    paths: ["docs/wiki/**", ".vitepress/**"]
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
 
 jobs:
-  update-wiki:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Sync to Wiki
-        uses: Andrew-Chen-Wang/github-wiki-action@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          path: docs/wiki
-          commit-message: "docs: auto-sync wiki from main"
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm add -D vitepress vue
+
+      - name: Build with VitePress
+        run: npx vitepress build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .vitepress/dist
+
+  deploy:
+    environment:
+      name: "pages"
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -1,0 +1,63 @@
+import { defineConfig } from "vitepress";
+
+export default defineConfig({
+  title: "Zero-Drag Dotfiles",
+  description: "A systems-thinking approach to Hyprland & Arch Linux",
+
+  // High-Agency Setup: Point to your existing wiki folder
+  srcDir: "docs/wiki",
+
+  // Professional URLs: Removes .html from the end
+  cleanUrls: true,
+
+  // GitHub Pages Path: Matches your repo name
+  base: "/Zero_Drag.dotfiles/",
+
+  // Map Home.md to index.md so it becomes the landing page
+  rewrites: {
+    "Home.md": "index.md",
+  },
+
+  themeConfig: {
+    logo: "https://raw.githubusercontent.com/babyanonymouse/Zero_Drag.dotfiles/main/peolabs-logo.svg",
+    nav: [
+      { text: "Home", link: "/" },
+      { text: "Installation", link: "/Installation" },
+    ],
+
+    sidebar: [
+      {
+        text: "Getting Started",
+        items: [
+          { text: "Installation", link: "/Installation" },
+          { text: "Configuration", link: "/Configuration" },
+          { text: "Keybindings", link: "/Keybindings" },
+        ],
+      },
+      {
+        text: "Core Components",
+        items: [
+          { text: "Shell Setup", link: "/Shell-Setup" },
+          { text: "UI Customization", link: "/Customization" },
+          { text: "Components", link: "/Components" },
+        ],
+      },
+      {
+        text: "Resources",
+        items: [{ text: "Troubleshooting", link: "/Troubleshooting" }],
+      },
+    ],
+
+    socialLinks: [
+      {
+        icon: "github",
+        link: "https://github.com/babyanonymouse/Zero_Drag.dotfiles",
+      },
+    ],
+
+    footer: {
+      message: "Released under the MIT License.",
+      copyright: "Copyright © 2026-present Samuel Lwanga",
+    },
+  },
+});


### PR DESCRIPTION
This pull request migrates the documentation deployment process from syncing to the GitHub Wiki to building and deploying a static site using VitePress and GitHub Pages. It introduces a new VitePress configuration and updates the GitHub Actions workflow to automate building and deploying the documentation site. The most important changes are grouped below:

**Documentation Deployment Workflow Migration:**

- The `.github/workflows/wiki-sync.yml` workflow is rewritten to build documentation using VitePress and deploy it to GitHub Pages instead of syncing to the GitHub Wiki. This includes setting up Node.js, installing dependencies, building the site, and deploying the output (`.vitepress/dist`) to GitHub Pages.
- Workflow permissions and concurrency are updated to support GitHub Pages deployment, including adding `pages: write` and `id-token: write` permissions and introducing a concurrency group for deployments.

**VitePress Site Configuration:**

- A new `.vitepress/config.mts` file is added, configuring site metadata, navigation, sidebar structure, social links, and GitHub Pages-specific settings such as the `base` path and source directory. It also maps `Home.md` to `index.md` for the landing page.